### PR TITLE
Force Gtk version 3.0

### DIFF
--- a/playitslowly/app.py
+++ b/playitslowly/app.py
@@ -32,6 +32,7 @@ except ImportError:
 
 import gi
 gi.require_version('Gst', '1.0')
+gi.require_version('Gtk', '3.0')
 
 from gi.repository import Gtk, GObject, Gst, Gio, Gdk
 


### PR DESCRIPTION
When Gtk4 is installed, Import fails:
AttributeError: 'gi.repository.Gtk' object has no attribute 'Container'

PyGObject is not yet updated to support GTK4. See:
https://gitlab.gnome.org/GNOME/pygobject/-/issues/423